### PR TITLE
Replace button > img nesting with more semantic input with image type.

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -74,9 +74,11 @@ label {
   width: 400px;
 }
 
-.search-section button {
+.search-section .search-button {
   font-size: 17px;
-  height: 30px;
+  width: 37px;
+  height: auto;
+  padding: 2px 6px 3px 6px;
   background-color: white;
   border: 1px solid #DDDDDD;
   border-radius: 3px;

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
     <form action="#">
       <label for="search">Search Jobs</label>
       <input type="text" id="search" placeholder="Developer, designer, internship..." />
-      <input type="image" class="search-button magnifying-glass-icon" src ="images/magnifying-glass.png" role="button" aria-label="Submit">
+      <input type="image" class="search-button magnifying-glass-icon" src ="images/magnifying-glasss.png" alt="Search" role="button">
     </form>
   </section>
 

--- a/index.html
+++ b/index.html
@@ -29,9 +29,7 @@
     <form action="#">
       <label for="search">Search Jobs</label>
       <input type="text" id="search" placeholder="Developer, designer, internship..." />
-      <button type="submit" class="search-button">
-        <img src="images/magnifying-glass.png" class="magnifying-glass-icon">
-      </button>
+      <input type="image" class="search-button magnifying-glass-icon" src ="images/magnifying-glass.png" role="button" aria-label="Submit">
     </form>
   </section>
 

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
     <form action="#">
       <label for="search">Search Jobs</label>
       <input type="text" id="search" placeholder="Developer, designer, internship..." />
-      <input type="image" class="search-button magnifying-glass-icon" src ="images/magnifying-glasss.png" alt="Search" role="button">
+      <input type="image" class="search-button magnifying-glass-icon" src ="images/magnifying-glass.png" alt="Search" role="button">
     </form>
   </section>
 


### PR DESCRIPTION
A `button` isn't meant to contain things, so using an [explicit image-typed input](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/image) in our solution might be set a better example. `role="button"` makes sure that this image input is treated the same as traditional buttons. 

I don't think we have to expect students to know this – I didn't even know this type existed until a couple weeks ago! – but we can have it here to set a good example & mentors can teach it if students ask about it, maybe?

Additionally, some small changes to the CSS so that the magnifying glass looks the same as it did before.