### PR TITLE
Remove .star-icon

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -132,6 +132,6 @@ label {
   vertical-align: bottom;
 }
 
-.star-icon, .magnifying-glass-icon {
+.magnifying-glass-icon {
   height: 100%;
 }


### PR DESCRIPTION
`.star-icon` not needed as no element with class `star-icon` exists.